### PR TITLE
Ensure that releases e.g. from 9.5.1 via 10.0.0 to 10.0.1 will smooth…

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -17,7 +17,7 @@
 
 [alias]
   tree = log --graph --full-history --all --color --date=short --pretty=format:\"%Cred%x09%h %Creset%ad%Cblue%d %Creset %s %C(bold)(%an)%Creset\"
-  semver = "!f() { SEMVER=`git tag | grep -Eo '\\d+\\.\\d+\\.\\d+' | sort | tail -1`; if [ '_' == _$SEMVER ]; then echo `git config --get semver.initial`; else echo $SEMVER; fi; }; f"
+  semver = "!f() { SEMVER=`git tag | grep -Eo '\\d+\\.\\d+\\.\\d+' | sort -V | tail -1`; if [ '_' == _$SEMVER ]; then echo `git config --get semver.initial`; else echo $SEMVER; fi; }; f"
   bumpsemver = "!f(){ PREFIX=$(git config --global --get semver.prefix); if [ -z \"$2\" ]; then MSG=\"-m \\\"$1 bump on `git semver`\"\\\"; else MSG=\"-m  \\\"$2\\\"\"; fi; levels=(`echo $(git semver) | tr '.' ' '`); if [ '_--major' == _$1 ]; then echo git tag -a $MSG $PREFIX$((${levels[0]}+1)).0.0; elif [ '_--minor' == _$1 ]; then echo git tag -a $MSG $PREFIX${levels[0]}.$((${levels[1]}+1)).0; elif [ '_--patch' == _$1 ]; then echo git tag -a $MSG $PREFIX${levels[0]}.${levels[1]}.$((${levels[2]}+1)); else echo 'Usage: git bumpsemver  --major|--minor|--patch [msg]\\n\\nGenerates the git command to run. If you omit\\nthe [msg] a clever one will be generated for you.\\nTo execute it run it in an eval  like this example:\\n\\n    eval $(git bumpsemver --minor \"this will be the comment\")'; fi;  }; f"
   root = rev-parse --show-toplevel
   repo-config-to-global = "!f(){ for f in $(git config --file `git root`/.gitconfig --list --name-only); do git config --global --get $f > /dev/null || git config --global $f \"$(git config --file `git root`/.gitconfig --get $f)\"; done; }; f"


### PR DESCRIPTION
…ly happen even during vacation time :-).
If sort did not have option -V, the `sort -V` expression could be achieved e.g. with 
`perl -e 'print [ map { $_->[0] } sort { $b->[1] cmp $a->[1] } map{ [ $_, $_ =~ s/(\d+)/sprintf("%05d", $1)/ger ] } <STDIN> ]->[0]'` .